### PR TITLE
Removed screen_icon()

### DIFF
--- a/classes/settings.inc
+++ b/classes/settings.inc
@@ -47,7 +47,6 @@ class settings
 	function render_settings_form() {
 		?>
 		<div class="wrap">
-			<?php screen_icon(); ?>
 			<h2><?php _e('Grid Settings', 'grid'); ?></h2>
 			<form method="post" action="options.php">
 				<?php


### PR DESCRIPTION
> Notice: screen_icon ist seit Version 3.8.0 veraltet. Es ist keine Alternative erhältlich.