### PR TITLE
fix redirect to admin.php

### DIFF
--- a/public/classes/Privileges.php
+++ b/public/classes/Privileges.php
@@ -48,14 +48,14 @@ class Privileges
 				}
 			}
 			update_option( 'grid_privileges', $privileges );
-			wp_redirect( add_query_arg( array( 'page' => 'grid_privileges' ), admin_url( 'tools.php' ) ) );
+			wp_redirect( add_query_arg( array( 'page' => 'grid_privileges' ), admin_url( 'admin.php' ) ) );
 			return;
 		}
 		$privileges = grid_wp_get_privs();
 		wp_enqueue_style( 'grid_css_wordpress', $this->plugin->url. 'css/grid-wordpress.css' );
 
 		?>
-		<form method="post" action="<?php echo add_query_arg( array( 'noheader' => true, 'page' => 'grid_privileges' ), admin_url( 'tools.php' ) );?>">
+		<form method="post" action="<?php echo add_query_arg( array( 'noheader' => true, 'page' => 'grid_privileges' ), admin_url( 'admin.php' ) );?>">
 			<table cellspacing="0" cellpadding="0" class="grid-privileges-editor">
 				<tr>
 					<th>Role</th>

--- a/public/classes/ReuseBox.php
+++ b/public/classes/ReuseBox.php
@@ -53,7 +53,7 @@ class ReuseBox extends _Component
 		grid_enqueue_editor_files($editor);
 		$html = $editor->runDelete( $this->plugin->gridCore->storage, $boxid );
 		if ( true === $html ) {
-			wp_redirect( add_query_arg( array( 'page' => 'grid_reuse_boxes' ), admin_url( 'tools.php' ) ) );
+			wp_redirect( add_query_arg( array( 'page' => 'grid_reuse_boxes' ), admin_url( 'admin.php' ) ) );
 			return;
 		}
 		echo $html;

--- a/public/classes/ReuseContainer.php
+++ b/public/classes/ReuseContainer.php
@@ -53,7 +53,7 @@ class ReuseContainer extends _Component
 		grid_enqueue_editor_files( $editor );
 		$html = $editor->runDelete( $this->plugin->gridCore->storage, $containerid );
 		if ( true === $html ) {
-			wp_redirect( add_query_arg( array( 'page' => 'grid_reuse_containers' ), admin_url( 'tools.php' ) ) );
+			wp_redirect( add_query_arg( array( 'page' => 'grid_reuse_containers' ), admin_url( 'admin.php' ) ) );
 			return;
 		}
 		echo $html;


### PR DESCRIPTION
I suppose in the past grid was situated under `tools.php`. With this fix the privilege form can be used again and reuse-boxes / reuse-containers can be deleted without error.